### PR TITLE
Generic Cloudinary Search API client (dependency injection) and default API client (11ty Cache)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "eleventy-plugin-embed-cloudinary",
-  "version": "0.0.0",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.0",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy-cache-assets": "^2.2.1"

--- a/src/.eleventy.ts
+++ b/src/.eleventy.ts
@@ -1,9 +1,15 @@
-import { defaultConfig, UserConfig } from './config';
+import { defaultPluginConfig, PluginConfig, UserConfig } from './config';
 import { cloudinaryRespImage } from './shortcodes';
 import { makeEmbedCloudinary } from './transforms';
 
 export const configFunction = (eleventyConfig: any, userConfig: UserConfig) => {
-  const pluginConfig = Object.assign({}, defaultConfig, userConfig);
+  // plugin config with no missing fields
+  const pluginConfig: Required<PluginConfig> = Object.assign(
+    {},
+    defaultPluginConfig,
+    userConfig
+  );
+
   eleventyConfig.addShortcode('cloudinaryRespImage', cloudinaryRespImage);
   eleventyConfig.addTransform(
     'embedCloudinary',

--- a/src/cloudinary-api-client.ts
+++ b/src/cloudinary-api-client.ts
@@ -1,45 +1,61 @@
-import Cache from '@11ty/eleventy-cache-assets';
-import { PluginConfig } from './config';
+import Cache, { EleventyCacheOptions } from '@11ty/eleventy-cache-assets';
+import { CloudinaryAuthConfig, CloudinaryClientConfig } from './config';
+import { messageImageHasNoAlt, messageImageHasNoCaption } from './errors';
 
-// Fetch an image hosted on your Cloudinary Media Library using the Cloudinary
-// Search API. Cache each response using the 11ty Cache.
-// Note: there is an official Node.js API client library, but it seems overkill
-// to use a full-fledged API client for this simple use case.
-// https://github.com/cloudinary/cloudinary_npm
-export const fetchFromCloudinary = async (
-  cloudName: string,
-  publicId: string,
-  pluginConfig: PluginConfig
+interface CloudinaryResource {
+  width: number;
+  height: number;
+  public_id: string;
+  context: {
+    alt?: string;
+    caption?: string;
+    description?: string;
+  };
+}
+
+export interface CloudinaryResponse {
+  resources: CloudinaryResource[];
+}
+
+type FetchOptions = any;
+
+export interface ImageResponse {
+  width: number;
+  height: number;
+  alt?: string;
+  caption?: string;
+}
+
+export type FetchImplementation = (
+  url: string,
+  options: FetchOptions
+) => Promise<any>;
+export type FetchFromCloudinary = (publicId: string) => Promise<ImageResponse>;
+
+export type MakeGenericAPIClient = (
+  clientConfig: CloudinaryClientConfig,
+  fetchImplementation: FetchImplementation,
+  fetchOptions?: FetchOptions
+) => FetchFromCloudinary;
+
+export type MakeAPIClient = (
+  clientConfig: CloudinaryClientConfig,
+  eleventyCacheOptions: EleventyCacheOptions
+) => FetchFromCloudinary;
+
+const toImageResponse = (
+  response: CloudinaryResponse,
+  shouldThrowOnMissingAlt?: boolean,
+  shouldThrowOnMissingCaption?: boolean
 ) => {
-  const baseUrl = `https://${pluginConfig.apiKey}:${pluginConfig.apiSecret}@api.cloudinary.com/v1_1/${cloudName}`;
-  const apiEndpoint = `${baseUrl}/resources/search`;
-  // %3A is for colon and %20 is for space
-  const qs = `expression=resource_type%3Aimage%20AND%20public_id%3A${publicId}&with_field=context&max_results=1`;
-  const url = `${apiEndpoint}?${qs}`;
-
-  // https://github.com/11ty/eleventy-cache-assets
-  const response = await Cache(url, {
-    directory: pluginConfig.cacheDirectory,
-    duration: pluginConfig.cacheDuration,
-    type: 'json',
-  });
-
   const r = response.resources[0];
 
-  if (pluginConfig.shouldThrowOnMissingAlt && r.context.alt === undefined) {
-    // or console.error?
-    throw new Error(
-      `Image with public_id ${r.public_id} has no 'Description (alt)' metadata. Update the image on your Cloudinary media library.`
-    );
+  if (shouldThrowOnMissingAlt && r.context.alt === undefined) {
+    throw new Error(messageImageHasNoAlt(r.public_id));
   }
 
-  if (
-    pluginConfig.shouldThrowOnMissingCaption &&
-    r.context.caption === undefined
-  ) {
-    throw new Error(
-      `Image with public_id ${r.public_id} has no 'Title (caption)' metadata. Update the image on your Cloudinary media library.`
-    );
+  if (shouldThrowOnMissingCaption && r.context.caption === undefined) {
+    throw new Error(messageImageHasNoCaption(r.public_id));
   }
 
   return {
@@ -47,5 +63,79 @@ export const fetchFromCloudinary = async (
     height: r.height as number,
     alt: (r.context.alt as string) || undefined,
     caption: (r.context.caption as string) || undefined,
+  };
+};
+
+type GetEndpoint = (auth: CloudinaryAuthConfig) => string;
+
+const getEndpoint: GetEndpoint = ({ apiKey, apiSecret, cloudName }) => {
+  const baseUrl = `https://${apiKey}:${apiSecret}@api.cloudinary.com/v1_1/${cloudName}`;
+  return `${baseUrl}/resources/search`;
+};
+
+// Fetch an image hosted on your Cloudinary Media Library using the Cloudinary
+// Search API. The caller needs to pass a `fetch` implementation.
+// Note: there is an official Node.js API client library, but it seems overkill
+// to use a full-fledged API client for this simple use case.
+// https://github.com/cloudinary/cloudinary_npm
+export const makeGenericAPIClient: MakeGenericAPIClient = (
+  clientConfig,
+  fetchImplementation,
+  fetchOptions
+) => {
+  const {
+    apiKey,
+    apiSecret,
+    cloudName,
+    shouldThrowOnMissingAlt,
+    shouldThrowOnMissingCaption,
+  } = clientConfig;
+
+  const apiEndpoint = getEndpoint({ apiKey, apiSecret, cloudName });
+
+  return async function apiClient(publicId) {
+    const qs = `expression=resource_type%3Aimage%20AND%20public_id%3A${publicId}&with_field=context&max_results=1`;
+    const url = `${apiEndpoint}?${qs}`;
+
+    const response: CloudinaryResponse = await fetchImplementation(
+      url,
+      fetchOptions
+    );
+
+    return toImageResponse(
+      response,
+      shouldThrowOnMissingAlt,
+      shouldThrowOnMissingCaption
+    );
+  };
+};
+
+// Fetch an image hosted on your Cloudinary Media Library using the Cloudinary
+// Search API. Cache each response using the 11ty Cache.
+// https://github.com/11ty/eleventy-cache-assets
+export const makeAPIClient: MakeAPIClient = (
+  clientConfig,
+  eleventyCacheOptions
+) => {
+  const {
+    apiKey,
+    apiSecret,
+    cloudName,
+    shouldThrowOnMissingAlt,
+    shouldThrowOnMissingCaption,
+  } = clientConfig;
+
+  const apiEndpoint = getEndpoint({ apiKey, apiSecret, cloudName });
+
+  return async function apiClient(publicId) {
+    const qs = `expression=resource_type%3Aimage%20AND%20public_id%3A${publicId}&with_field=context&max_results=1`;
+    const url = `${apiEndpoint}?${qs}`;
+
+    const response: CloudinaryResponse = await Cache(url, eleventyCacheOptions);
+    return toImageResponse(
+      response,
+      shouldThrowOnMissingAlt,
+      shouldThrowOnMissingCaption
+    );
   };
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,29 +1,52 @@
-export interface BasicConfig {
-  cacheDirectory: string;
-  cacheDuration: string;
-  classString: string;
-  shouldLazyLoad: boolean;
-  shouldThrowOnMissingAlt: boolean;
-  shouldThrowOnMissingCaption: boolean;
-}
-
-export interface RequiredConfig {
+// Fields required to authenticate with Cloudinary.
+export interface CloudinaryAuthConfig {
   apiKey: string;
   apiSecret: string;
+  cloudName: string;
 }
 
-export interface PluginConfig extends BasicConfig {
-  apiKey: string;
-  apiSecret: string;
+// Optional fields to configure the Cloudinary client.
+export interface CloudinaryClientOptions {
+  shouldThrowOnMissingAlt?: boolean;
+  shouldThrowOnMissingCaption?: boolean;
 }
 
-export type UserConfig = RequiredConfig & Partial<BasicConfig>;
+export const defaultCloudinaryClientConfig: Required<CloudinaryClientOptions> = {
+  shouldThrowOnMissingAlt: false,
+  shouldThrowOnMissingCaption: false,
+};
 
-export const defaultConfig: BasicConfig = {
+// All non-Cloudinary optional fields.
+export interface NonCloudinaryOptions {
+  cacheDirectory?: string;
+  cacheDuration?: string;
+  classString?: string;
+  shouldLazyLoad?: boolean;
+}
+
+export const defaultNonCloudinaryConfig: Required<NonCloudinaryOptions> = {
   cacheDirectory: '.cache',
   cacheDuration: '30m',
   classString: '',
   shouldLazyLoad: true,
-  shouldThrowOnMissingAlt: false,
-  shouldThrowOnMissingCaption: false,
 };
+
+export type PluginOptions = CloudinaryClientOptions & NonCloudinaryOptions;
+
+export const defaultPluginConfig = {
+  ...defaultCloudinaryClientConfig,
+  ...defaultNonCloudinaryConfig,
+};
+
+// Configuration for any Cloudinary client. A Cloudinary client doesn't
+// necessarily cache HTTP requests.
+export type CloudinaryClientConfig = CloudinaryAuthConfig &
+  CloudinaryClientOptions;
+
+export type UserConfig = CloudinaryAuthConfig &
+  Partial<CloudinaryClientOptions> &
+  Partial<NonCloudinaryOptions>;
+
+export type PluginConfig = CloudinaryAuthConfig &
+  CloudinaryClientOptions &
+  NonCloudinaryOptions;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,13 @@
+import { ImageData } from './interfaces';
+
+export const messageImageHasNoAlt = (public_id: string) => {
+  return `Image with public_id ${public_id} has no 'Description (alt)' metadata. Update the image on your Cloudinary media library.`;
+};
+
+export const messageImageHasNoCaption = (public_id: string) => {
+  return `Image with public_id ${public_id} has no 'Title (caption)' metadata. Update the image on your Cloudinary media library.`;
+};
+
+export const messageImageIsNotOwned = (cloudName: string, data: ImageData) => {
+  return `Your Cloudinary cloud_name is ${cloudName}. You cannot fetch the image with public_id ${data.publicId} because it belongs to cloud_name ${data.cloudName}`;
+};

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,0 +1,6 @@
+export interface ImageData {
+  cloudName: string;
+  format: string;
+  publicId: string;
+  version: string;
+}

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -1,10 +1,31 @@
+import { makeAPIClient } from './cloudinary-api-client';
 import { PluginConfig } from './config';
+import { messageImageIsNotOwned } from './errors';
 import { getData, getMatches } from './regex';
-import { fetchFromCloudinary } from './cloudinary-api-client';
 import { cloudinaryRespImage } from './shortcodes';
 
-export const makeEmbedCloudinary = (pluginConfig: PluginConfig) => {
-  return async (content: string, outputPath: string) => {
+type EmbedCloudinary = (content: string, outputPath: string) => Promise<string>;
+
+type MakeEmbedCloudinary = (
+  pluginConfig: Required<PluginConfig>
+) => EmbedCloudinary;
+
+export const makeEmbedCloudinary: MakeEmbedCloudinary = pluginConfig => {
+  const eleventyCacheOptions = {
+    directory: pluginConfig.cacheDirectory,
+    duration: pluginConfig.cacheDuration,
+    type: 'json' as 'buffer' | 'json' | 'text',
+  };
+  const { apiKey, apiSecret, cloudName } = pluginConfig;
+  const fetchFromCloudinary = makeAPIClient(
+    {
+      apiKey,
+      apiSecret,
+      cloudName,
+    },
+    eleventyCacheOptions
+  );
+  return async function embdedCloudinary(content, outputPath) {
     if (outputPath && outputPath.endsWith('.html')) {
       const matches = getMatches(content);
       if (!matches) {
@@ -16,11 +37,12 @@ export const makeEmbedCloudinary = (pluginConfig: PluginConfig) => {
         if (!data) {
           return content;
         }
-        const responseData = await fetchFromCloudinary(
-          data.cloudName,
-          data.publicId,
-          pluginConfig
-        );
+
+        if (data.cloudName !== cloudName) {
+          throw new Error(messageImageIsNotOwned(cloudName, data));
+        }
+
+        const responseData = await fetchFromCloudinary(data.publicId);
         const src = `https://res.cloudinary.com/${data.cloudName}/image/upload/v${data.version}/${data.publicId}.${data.format}`;
         // TODO: make this configurable? cloudinaryRespImage could be a custom
         // function set when configuring this plugin. This would allow a user to

--- a/test/.eleventy.test.ts
+++ b/test/.eleventy.test.ts
@@ -5,7 +5,8 @@ import eleventyConfig from '@11ty/eleventy/src/EleventyConfig';
 describe('configFunction', () => {
   const apiKey = process.env.CLOUDINARY_API_KEY as string;
   const apiSecret = process.env.CLOUDINARY_API_SECRET as string;
-  const userConfig = { apiKey, apiSecret };
+  const cloudName = process.env.CLOUDINARY_CLOUD_NAME as string;
+  const userConfig = { apiKey, apiSecret, cloudName };
 
   it('has a valid configuration function', () => {
     expect(() => configFunction(eleventyConfig, userConfig)).not.toThrow();

--- a/test/cloudinary-api-client.test.ts
+++ b/test/cloudinary-api-client.test.ts
@@ -1,32 +1,239 @@
-import { fetchFromCloudinary } from '../src/cloudinary-api-client';
-import { defaultConfig } from '../src/config';
+import {
+  FetchImplementation,
+  makeAPIClient,
+  makeGenericAPIClient,
+} from '../src/cloudinary-api-client';
+import { CloudinaryClientConfig } from '../src/config';
+import { messageImageHasNoAlt, messageImageHasNoCaption } from '../src/errors';
 
-// TODO: avoid real API calls. Mock them.
+const CAPTION_FRESH_RESPONSE = 'This is a FRESH response';
+const freshResponse = {
+  resources: [
+    {
+      width: 123,
+      height: 456,
+      public_id: 'mock_cloudinary_public_id',
+      context: {
+        alt: 'mock alt text',
+        caption: CAPTION_FRESH_RESPONSE,
+        description: 'mock description',
+      },
+    },
+  ],
+};
 
-describe('fetchFromCloudinary', () => {
-  it('throws with invalid config', async () => {
-    const cloudName = 'non-existing-cloud-name';
-    const publicId = 'public_id_of_an_image';
-    const apiKey = 'invalidApiKey';
-    const apiSecret = 'invalidApiSecret';
-    const config = { ...defaultConfig, apiKey, apiSecret };
+const CAPTION_CACHED_RESPONSE = 'This is a CACHED response';
+const cachedResponse = {
+  resources: [
+    {
+      width: 123,
+      height: 456,
+      public_id: 'mock_cloudinary_public_id',
+      context: {
+        alt: 'mock alt text',
+        caption: CAPTION_CACHED_RESPONSE,
+        description: 'mock description',
+      },
+    },
+  ],
+};
 
-    await expect(
-      fetchFromCloudinary(cloudName, publicId, config)
-    ).rejects.toThrow();
-  });
+const PUBLIC_ID_MISSING_ALT = 'mock_cloudinary_public_id_no_alt';
+const imageResponseWithMissingAlt = {
+  resources: [
+    {
+      width: 123,
+      height: 456,
+      public_id: PUBLIC_ID_MISSING_ALT,
+      context: {
+        caption: 'mock caption',
+        description: 'mock description',
+      },
+    },
+  ],
+};
 
-  it('returns the expected response', async () => {
-    const cloudName = process.env.CLOUDINARY_CLOUD_NAME as string;
+const PUBLIC_ID_MISSING_CAPTION = 'mock_cloudinary_public_id_no_caption';
+const imageResponseWithMissingCaption = {
+  resources: [
+    {
+      width: 123,
+      height: 456,
+      public_id: PUBLIC_ID_MISSING_CAPTION,
+      context: {
+        alt: 'mock alt text',
+        description: 'mock description',
+      },
+    },
+  ],
+};
+
+// true means that the corresponding image attribute is missing
+interface MissingImageAttr {
+  alt?: boolean;
+  caption?: boolean;
+}
+
+const makeMockFetchWithMissingImageAttr = (
+  missingImageFields: MissingImageAttr
+) => {
+  const fetchImplementation: FetchImplementation = _url => {
+    return new Promise(resolve => {
+      process.nextTick(() => {
+        if (missingImageFields.alt) {
+          resolve(imageResponseWithMissingAlt);
+        } else if (missingImageFields.caption) {
+          resolve(imageResponseWithMissingCaption);
+        } else {
+          resolve(freshResponse);
+        }
+      });
+    });
+  };
+  return fetchImplementation;
+};
+
+const accountConfigValid: CloudinaryClientConfig = {
+  apiKey: process.env.CLOUDINARY_API_KEY as string,
+  apiSecret: process.env.CLOUDINARY_API_SECRET as string,
+  cloudName: process.env.CLOUDINARY_CLOUD_NAME as string,
+};
+
+const makeMockFetchWithCache = () => {
+  const cache = new Map<string, boolean>();
+  const fetchImplementation: FetchImplementation = url => {
+    return new Promise(resolve => {
+      process.nextTick(() => {
+        const seen = cache.get(url);
+        if (seen) {
+          resolve(cachedResponse);
+        } else {
+          cache.set(url, true);
+          resolve(freshResponse);
+        }
+      });
+    });
+  };
+  return fetchImplementation;
+};
+
+describe('fetchFromCloudinary (mock)', () => {
+  it('returns the expected response (mock)', async () => {
+    const fetchFromCloudinary = makeGenericAPIClient(
+      accountConfigValid,
+      makeMockFetchWithCache()
+    );
     const publicId = process.env.CLOUDINARY_IMAGE_PUBLIC_ID as string;
-    const apiKey = process.env.CLOUDINARY_API_KEY as string;
-    const apiSecret = process.env.CLOUDINARY_API_SECRET as string;
-    const config = { ...defaultConfig, apiKey, apiSecret };
 
-    const result = await fetchFromCloudinary(cloudName, publicId, config);
+    const result = await fetchFromCloudinary(publicId);
+
     expect(result).toHaveProperty('width');
     expect(result).toHaveProperty('height');
     expect(result).toHaveProperty('alt');
     expect(result).toHaveProperty('caption');
+  });
+
+  it('returns a cached response (mock)', async () => {
+    const fetchFromCloudinary = makeGenericAPIClient(
+      accountConfigValid,
+      makeMockFetchWithCache(),
+      { someFetchOption: 'foo' }
+    );
+    const publicId = process.env.CLOUDINARY_IMAGE_PUBLIC_ID as string;
+
+    const fresh = await fetchFromCloudinary(publicId);
+    expect(fresh.caption).toBe(CAPTION_FRESH_RESPONSE);
+
+    const cached = await fetchFromCloudinary(publicId);
+    expect(cached.caption).toBe(CAPTION_CACHED_RESPONSE);
+  });
+
+  it('throws with the expected error message when the image `alt` is missing, and the client was configured to throw when this occurs (mock)', async () => {
+    const clientConfig = {
+      ...accountConfigValid,
+      shouldThrowOnMissingAlt: true,
+    };
+    const fetchFromCloudinary = makeGenericAPIClient(
+      clientConfig,
+      makeMockFetchWithMissingImageAttr({ alt: true })
+    );
+    const publicId = PUBLIC_ID_MISSING_ALT;
+    const expectedErrorMessage = messageImageHasNoAlt(publicId);
+
+    await expect(fetchFromCloudinary(publicId)).rejects.toThrowError(
+      expectedErrorMessage
+    );
+  });
+
+  it('throws with the expected error message when the image `caption` is missing, and the client was configured to throw when this occurs (mock)', async () => {
+    const clientConfig = {
+      ...accountConfigValid,
+      shouldThrowOnMissingCaption: true,
+    };
+    const fetchFromCloudinary = makeGenericAPIClient(
+      clientConfig,
+      makeMockFetchWithMissingImageAttr({ caption: true })
+    );
+    const publicId = PUBLIC_ID_MISSING_CAPTION;
+    const expectedErrorMessage = messageImageHasNoCaption(publicId);
+
+    await expect(fetchFromCloudinary(publicId)).rejects.toThrowError(
+      expectedErrorMessage
+    );
+  });
+});
+
+describe('fetchFromCloudinary (network)', () => {
+  // 11ty Cache options
+  const cacheOptions = {
+    directory: '.cache',
+    duration: '5s',
+    type: 'json' as 'buffer' | 'json' | 'text',
+  };
+
+  it('throws when configured with invalid Cloudinary account credentials (network)', async () => {
+    const clientConfigWithInvalidCredentials = {
+      apiKey: 'invalid_api_key',
+      apiSecret: 'invalid_api_secret',
+      cloudName: 'invalid_clound_name',
+    };
+    const fetchFromCloudinary = makeAPIClient(
+      clientConfigWithInvalidCredentials,
+      cacheOptions
+    );
+    const publicId = 'public_id_of_an_image';
+
+    try {
+      await fetchFromCloudinary(publicId);
+      expect(true).toBe(false); // so if fetch succeeds, this test fails
+    } catch (e) {
+      expect(e.message).toContain('401');
+      expect(e.message).toContain('Unauthorized');
+    }
+
+    // await expect(fetchFromCloudinary(publicId)).rejects.toThrowError('aaa');
+  });
+
+  it('returns an image response with width,height,alt,caption (network)', async () => {
+    const fetchFromCloudinary = makeAPIClient(accountConfigValid, cacheOptions);
+    const publicId = process.env.CLOUDINARY_IMAGE_PUBLIC_ID as string;
+
+    const result = await fetchFromCloudinary(publicId);
+
+    expect(result).toHaveProperty('width');
+    expect(result).toHaveProperty('height');
+    expect(result).toHaveProperty('alt');
+    expect(result).toHaveProperty('caption');
+  });
+
+  it('returns a cached response (network)', async () => {
+    const fetchFromCloudinary = makeAPIClient(accountConfigValid, cacheOptions);
+    const publicId = process.env.CLOUDINARY_IMAGE_PUBLIC_ID as string;
+
+    const fresh = await fetchFromCloudinary(publicId);
+    expect(fresh).toBeTruthy();
+
+    const cached = await fetchFromCloudinary(publicId);
+    expect(cached).toBeTruthy();
   });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,11 +1,19 @@
-import { defaultConfig } from '../src/config';
+import { defaultPluginConfig } from '../src/config';
 
 describe('defaultConfig', () => {
-  it('has the expected cache directory', () => {
-    expect(defaultConfig.cacheDirectory).toBe('.cache');
+  it('uses `.cache` as cache directory', () => {
+    expect(defaultPluginConfig.cacheDirectory).toBe('.cache');
   });
 
-  it('has the expected cache duration', () => {
-    expect(defaultConfig.cacheDuration).toBe('30m');
+  it('uses `30m` as cache duration', () => {
+    expect(defaultPluginConfig.cacheDuration).toBe('30m');
+  });
+
+  it('lazy loads images', () => {
+    expect(defaultPluginConfig.shouldLazyLoad).toBeTruthy();
+  });
+
+  it('has no custom CSS class', () => {
+    expect(defaultPluginConfig.classString).toBe('');
   });
 });

--- a/test/transforms.test.ts
+++ b/test/transforms.test.ts
@@ -1,26 +1,27 @@
-import { defaultConfig } from '../src/config';
+import { defaultPluginConfig } from '../src/config';
+import { messageImageIsNotOwned } from '../src/errors';
 import { makeEmbedCloudinary } from '../src/transforms';
 
 describe('makeEmbedCloudinary', () => {
   const apiKey = process.env.CLOUDINARY_API_KEY as string;
   const apiSecret = process.env.CLOUDINARY_API_SECRET as string;
-  const userConfig = { apiKey, apiSecret };
-
   const cloudName = process.env.CLOUDINARY_CLOUD_NAME as string;
-  const cloudNameInvalid = 'my_cloudinary_cloud_name';
-  const version = '1234567890';
-  const publicId = process.env.CLOUDINARY_IMAGE_PUBLIC_ID;
-  const publicIdInvalid = 'public_id_of_an_image';
+  const userConfig = { apiKey, apiSecret, cloudName };
+
+  const publicId = process.env.CLOUDINARY_IMAGE_PUBLIC_ID as string;
   const format = 'png';
+  const version = '1234567890';
 
   it('should not alter the content of a CSS file', async () => {
     const content = `
     .some-class {
       background-color: 'red';
     }`;
-    const pluginConfig = Object.assign({}, defaultConfig, userConfig);
+    const pluginConfig = Object.assign({}, defaultPluginConfig, userConfig);
     const embedCloudinary = makeEmbedCloudinary(pluginConfig);
+
     const replacedContent = await embedCloudinary(content, 'some-file.css');
+
     expect(replacedContent).toBe(content);
   });
 
@@ -30,34 +31,51 @@ describe('makeEmbedCloudinary', () => {
       <p>stuff</p>
       <p>more stuff</p>
     </div>`;
-    const pluginConfig = Object.assign({}, defaultConfig, userConfig);
+    const pluginConfig = Object.assign({}, defaultPluginConfig, userConfig);
     const embedCloudinary = makeEmbedCloudinary(pluginConfig);
+
     const replacedContent = await embedCloudinary(content, 'some-file.html');
+
     expect(replacedContent).toBe(content);
   });
 
-  it('throws with invalid config', async () => {
-    const content = `
+  it('throws with the expected error when the HTML contains an image not hosted on your Cloudinary account', async () => {
+    const NOT_YOUR_CLOUD_NAME = 'not_your_cloud_name';
+    // public_id of an image that is NOT hosted on your Cloudinary Media library
+    const NOT_OWNED_PUBLIC_ID = 'not_public_id';
+    const contentWithNotOwnedImage = `
     <div>
       <p>stuff</p>
-      <p><a href="https://res.cloudinary.com/${cloudNameInvalid}/image/upload/v${version}/${publicIdInvalid}.${format}">https://res.cloudinary.com/${cloudNameInvalid}/image/upload/v${version}/${publicIdInvalid}.${format}</a></p>
+      <p><a href="https://res.cloudinary.com/${NOT_YOUR_CLOUD_NAME}/image/upload/v${version}/${NOT_OWNED_PUBLIC_ID}.${format}">https://res.cloudinary.com/${NOT_YOUR_CLOUD_NAME}/image/upload/v${version}/${NOT_OWNED_PUBLIC_ID}.${format}</a></p>
       <p>more stuff</p>
     </div>`;
-    const pluginConfig = Object.assign({}, defaultConfig, userConfig);
+    const pluginConfig = Object.assign({}, defaultPluginConfig, userConfig);
+    const expectedErrorMessage = messageImageIsNotOwned(cloudName, {
+      cloudName: NOT_YOUR_CLOUD_NAME,
+      publicId: NOT_OWNED_PUBLIC_ID,
+      format,
+      version,
+    });
     const embedCloudinary = makeEmbedCloudinary(pluginConfig);
-    await expect(embedCloudinary(content, 'some-file.html')).rejects.toThrow();
+
+    await expect(
+      embedCloudinary(contentWithNotOwnedImage, 'some-file.html')
+    ).rejects.toThrowError(expectedErrorMessage);
   });
 
-  it('returns the expected response', async () => {
+  it('transforms the HTML content as expected (network)', async () => {
     const content = `
     <div>
       <p>stuff</p>
       <p><a href="https://res.cloudinary.com/${cloudName}/image/upload/v${version}/${publicId}.${format}">https://res.cloudinary.com/${cloudName}/image/upload/v${version}/${publicId}.${format}</a></p>
       <p>more stuff</p>
     </div>`;
-    const pluginConfig = Object.assign({}, defaultConfig, userConfig);
+    const pluginConfig = Object.assign({}, defaultPluginConfig, userConfig);
     const embedCloudinary = makeEmbedCloudinary(pluginConfig);
+
     const replacedContent = await embedCloudinary(content, 'some-file.html');
+
+    expect(replacedContent).not.toBe(content);
     expect(replacedContent).toContain('<img');
     expect(replacedContent).toContain('srcset=');
     expect(replacedContent).toContain('sizes=');

--- a/types/11ty__eleventy-cache-assets/index.d.ts
+++ b/types/11ty__eleventy-cache-assets/index.d.ts
@@ -1,9 +1,9 @@
 declare module '@11ty/eleventy-cache-assets' {
-  interface Options {
+  export interface EleventyCacheOptions {
     directory: string;
     duration: string;
     type: 'json' | 'text' | 'buffer';
   }
-  const Cache: (source: string, options: Options) => any;
+  const Cache: (source: string, options: EleventyCacheOptions) => Promise<any>;
   export default Cache;
 }


### PR DESCRIPTION
This PR introduces two factory functions to generate a [Cloudinary Search API](https://cloudinary.com/documentation/search_api) client.

1. a generic, pure function that uses dependency injection and accepts a fetch implementation;
2. a default, impure function that uses `Cache` from [eleventy-cache-assets](https://github.com/11ty/eleventy-cache-assets) to fetch requests and cache responses.

See #4  