### PR TITLE
Add workflow to generate a TOC in README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,3 @@ jobs:
         uses: coverallsapp/github-action@v1.1.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Jest coverage report (only in PR)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: ArtiomTr/jest-coverage-report-action@v1.3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          test_script: npm run test --ci --coverage

--- a/.github/workflows/generate-toc.yml
+++ b/.github/workflows/generate-toc.yml
@@ -1,0 +1,10 @@
+name: "Generate TOC"
+on: [pull_request]
+jobs:
+  generateTOC:
+    name: TOC Generator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: technote-space/toc-generator@v4
+        with:
+          FOLDING: true

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Eleventy plugin to automatically embed in markdown files any image hosted on you
 
 Write a URL → get a [responsive image](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images).
 
+<!-- START doctoc -->
+<!-- END doctoc -->
+
 ## Installation
 
 Install with npm or yarn.
@@ -78,3 +81,5 @@ npm run release:patch
 npm run release:minor
 npm run release:major
 ```
+
+Package size checked with [BundleWatch](https://bundlewatch.io/#/).

--- a/README.md
+++ b/README.md
@@ -6,8 +6,20 @@ Eleventy plugin to automatically embed in markdown files any image hosted on you
 
 Write a URL → get a [responsive image](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images).
 
-<!-- START doctoc -->
-<!-- END doctoc -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+<details>
+<summary>Table of Contents</summary>
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [Configuration](#configuration)
+  - [Required](#required)
+  - [Optional](#optional)
+- [Release management](#release-management)
+
+</details>
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Installation
 


### PR DESCRIPTION
This workflow uses a GitHub action to generate a Table of Contents and commit it to the README.

See:

- https://github.com/thlorenz/doctoc
- https://github.com/marketplace/actions/toc-generator